### PR TITLE
Add response to '/login' endpoint & remove 'secure' flag from session

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,7 +24,7 @@ app.use(
     saveUninitialized: true,
     cookie: {
       maxAge: 60 * 60 * 1000, // 1 hour
-      secure: true,
+      // secure: true, // Uncomment this line to enforce HTTPS protocol.
       sameSite: true
     }
   })

--- a/routes/user.js
+++ b/routes/user.js
@@ -55,7 +55,13 @@ const login = async (user, done) => {
 };
 
 /* Attach middleware to login endpoint */
-router.post("/login", passport.authenticate("magic"));
+router.post("/login", passport.authenticate("magic"), (req, res) => {
+  if (req.user) {
+      res.status(200).end('User is logged in.');
+  } else {
+     return res.status(401).end('Could not log user in.');
+  }
+});
 
 /* 4️⃣ Implement Session Behavior */
 


### PR DESCRIPTION
The example works fine in CodeSandbox, but breaks locally due to the `secure` attribute on the session cookie.

Also, the `/login` endpoint, while functional, always returns 404. This PR also resolves that issue.